### PR TITLE
Add ⭐️Weights and Biases⭐️ to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy==1.7.3
 torch==1.7.0
 torchvision==0.11.2
 tqdm==4.62.3
+wandb==0.12.10


### PR DESCRIPTION
Hey @hlml,👋  I noticed that your training scripts uses Weights and Biases for Experiment Tracking but you didn't have [**`wandb`**](https://pypi.org/project/wandb/) in your `requirements.txt`. This PR simply adds the package to the requirements.

It would also be nice if you could maybe add the Weights and Biases Project link in the README.md or in the Project Website in the Repository Settings. (For reference please refer to the image)


<details>

<summary>Reference Image</summary>

![Screenshot 2022-02-09 at 12 57 09 AM](https://user-images.githubusercontent.com/61241031/153061027-99cf5b36-2b32-4cbd-813e-79d764869c85.png)

</details>

---

PS: Congratulations to all the authors for ICLR'22 !! ☺️